### PR TITLE
getClosestN: Allow all members to be returned

### DIFF
--- a/consistent.go
+++ b/consistent.go
@@ -305,7 +305,7 @@ func (c *Consistent) getClosestN(partID, count int) ([]Member, error) {
 	defer c.mu.RUnlock()
 
 	res := []Member{}
-	if count > len(c.members)-1 {
+	if count > len(c.members) {
 		return res, ErrInsufficientMemberCount
 	}
 


### PR DESCRIPTION
Remove what I believe to be an off-by-one error in the comparison of `count` and the number of members.  This fixes the behavior I mentioned in #6.