### PR TITLE
[perf] Avoid unnecessary allocations in GetMembers.

### DIFF
--- a/consistent.go
+++ b/consistent.go
@@ -142,7 +142,7 @@ func (c *Consistent) GetMembers() []Member {
 	defer c.mu.RUnlock()
 
 	// Create a thread-safe copy of member list.
-	members := []Member{}
+	members := make([]Member, 0, len(c.members))
 	for _, member := range c.members {
 		members = append(members, *member)
 	}
@@ -221,7 +221,7 @@ func (c *Consistent) Add(member Member) {
 	defer c.mu.Unlock()
 
 	if _, ok := c.members[member.String()]; ok {
-		// We have already have this. Quit immediately.
+		// We already have this member. Quit immediately.
 		return
 	}
 	c.add(member)


### PR DESCRIPTION
Since we know the number of members in advance, there is no need
to dynamically resize `members` slice.