### PR TITLE
Fix Panic On A Particular Case

### DIFF
--- a/consistent.go
+++ b/consistent.go
@@ -185,11 +185,11 @@ func (c *Consistent) distributeWithLoad(partID, idx int, partitions map[int]*Mem
 	avgLoad := c.averageLoad()
 	var count int
 	for {
-		count++
 		if count >= len(c.sortedSet) {
 			// User needs to decrease partition count, increase member count or increase load factor.
 			panic("not enough room to distribute partitions")
 		}
+		count++
 		i := c.sortedSet[idx]
 		member := *c.ring[i]
 		load := loads[member.String()]


### PR DESCRIPTION
Consider a case, where member count is 2{0,1}, partitionCount=5, load=1.5 . 
```
func (c *Consistent) distributeWithLoad(partID, idx int, partitions map[int]*Member, loads map[string]float64) {
	...
}
```
Main problematic part of code give below:
```
for {
		if count >= len(c.sortedSet) {
			// User needs to decrease partition count, increase member count or increase load factor.
			panic("not enough room to distribute partitions")
		}
		count++
		i := c.sortedSet[idx]
		member := *c.ring[i]
		load := loads[member.String()]
		if load+1 <= avgLoad {
			partitions[partID] = &member
			loads[member.String()]++
			return
		}
		idx++
		if idx >= len(c.sortedSet) {
			idx = 0
		}
	}
```

Here the average load will be 3 i assume. So if i have 5 keys, lets assume first 3 keys will fall under member0, so for the fourth key, 
```
if load+1 <= avgLoad
```
this condition will be false, so we will increment the counter by one `count++`, which results count=2, now as len(c.sortedSet) is also equal 2, so because of below condition:
```
if count >= len(c.sortedSet) {
	// User needs to decrease partition count, increase member count or increase load factor.
	panic("not enough room to distribute partitions")
}
```
it won't be able to distribute load for member 2.
## Solution:
Either increase the count variable later or modify the condition to count > len(c.sortedSet)